### PR TITLE
Update README.md with the correct pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Installation
 ------------
 
  - clone this repository
- - `python3 -m pip install ../multi_fingering_eval`
+ - `python3 -m pip install .`
 
 Publication
 -----------


### PR DESCRIPTION
The previous pip install command `python3 -m pip install ../multi_fingering_eval` was not correct, and has been updated. The new command has been tested and works as intended.